### PR TITLE
fix: remove extraneous setUp calls

### DIFF
--- a/packages/contracts/test/systems/ManagerSystem.t.sol
+++ b/packages/contracts/test/systems/ManagerSystem.t.sol
@@ -24,8 +24,6 @@ contract ManagerSystemTest is BaseTest {
   // * * * *
 
   function testRevertNotAllowed() public {
-    setUp();
-
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
 
@@ -45,8 +43,6 @@ contract ManagerSystemTest is BaseTest {
   }
 
   function testApplyOutcomeEmpty() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -77,8 +73,6 @@ contract ManagerSystemTest is BaseTest {
   // * * * *
 
   function testApplyOutcomeIncreaseHealth() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -110,8 +104,6 @@ contract ManagerSystemTest is BaseTest {
   }
 
   function testApplyOutcomeReduceHealth() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -152,8 +144,6 @@ contract ManagerSystemTest is BaseTest {
   }
 
   function testApplyOutcomeOverIncreaseHealth() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -194,8 +184,6 @@ contract ManagerSystemTest is BaseTest {
   }
 
   function testApplyOutcomeOverReduceHealth() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -238,8 +226,6 @@ contract ManagerSystemTest is BaseTest {
   }
 
   function testApplyOutcomeValueTransferOnDeath() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -334,8 +320,6 @@ contract ManagerSystemTest is BaseTest {
   // * * * *
 
   function testApplyOutcomeAddPositiveTrait() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -374,8 +358,6 @@ contract ManagerSystemTest is BaseTest {
   }
 
   function testApplyOutcomeAddNegativeTrait() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -414,8 +396,6 @@ contract ManagerSystemTest is BaseTest {
   }
 
   function testApplyOutcomeAddPositiveTraitTooExpensive() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -451,8 +431,6 @@ contract ManagerSystemTest is BaseTest {
   }
 
   function testApplyOutcomeRemovePositiveTrait() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -503,8 +481,6 @@ contract ManagerSystemTest is BaseTest {
   }
 
   function testApplyOutcomeRemoveNegativeTrait() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -555,8 +531,6 @@ contract ManagerSystemTest is BaseTest {
   }
 
   // function testApplyOutcomeRemoveNegativeTraitTooExpensive() public {
-  //   setUp();
-
   //   // As alice
   //   vm.startPrank(alice);
   //   world.ratroom__spawn("alice");
@@ -626,8 +600,6 @@ contract ManagerSystemTest is BaseTest {
   // // * * * *
 
   function testApplyOutcomeAddPositiveItem() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -666,8 +638,6 @@ contract ManagerSystemTest is BaseTest {
   }
 
   function testApplyOutcomeAddNegativeItem() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -708,8 +678,6 @@ contract ManagerSystemTest is BaseTest {
   }
 
   function testApplyOutcomeAddPositiveItemTooExpensive() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -745,8 +713,6 @@ contract ManagerSystemTest is BaseTest {
   }
 
   function testApplyOutcomeRemovePositiveItem() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -802,8 +768,6 @@ contract ManagerSystemTest is BaseTest {
   // * * * * * * * * *
 
   function testApplyOutcomeTransferToRat() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -837,8 +801,6 @@ contract ManagerSystemTest is BaseTest {
   }
 
   function testApplyOutcomeTransferToRoom() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -880,8 +842,6 @@ contract ManagerSystemTest is BaseTest {
   }
 
   function testApplyOutcomeOverTransferToRat() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
@@ -922,8 +882,6 @@ contract ManagerSystemTest is BaseTest {
   }
 
   function testApplyOutcomeOverTransferToRoom() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     world.ratroom__spawn("alice");

--- a/packages/contracts/test/systems/PlayerSystem.t.sol
+++ b/packages/contracts/test/systems/PlayerSystem.t.sol
@@ -8,8 +8,6 @@ import { ENTITY_TYPE } from "../../src/codegen/common.sol";
 
 contract PlayerSystemTest is BaseTest {
   function testSpawn() public {
-    setUp();
-
     vm.startPrank(alice);
 
     startGasReport("Spawn");

--- a/packages/contracts/test/systems/RatSystem.t.sol
+++ b/packages/contracts/test/systems/RatSystem.t.sol
@@ -20,8 +20,6 @@ contract RatSystemTest is BaseTest {
   }
 
   function testCreateRat() public {
-    setUp();
-
     vm.startPrank(alice);
 
     bytes32 playerId = world.ratroom__spawn("alice");
@@ -48,8 +46,6 @@ contract RatSystemTest is BaseTest {
   }
 
   function testRevertAlreadyHasRat() public {
-    setUp();
-
     vm.startPrank(alice);
     world.ratroom__spawn("alice");
 
@@ -62,8 +58,6 @@ contract RatSystemTest is BaseTest {
   }
 
   function testLiquidateRat() public {
-    setUp();
-
     vm.startPrank(alice);
 
     bytes32 playerId = world.ratroom__spawn("alice");
@@ -84,8 +78,6 @@ contract RatSystemTest is BaseTest {
   }
 
   function testDropItem() public {
-    setUp();
-
     // As alice
     vm.startPrank(alice);
     bytes32 aliceId = world.ratroom__spawn("alice");

--- a/packages/contracts/test/systems/RoomSystem.t.sol
+++ b/packages/contracts/test/systems/RoomSystem.t.sol
@@ -19,8 +19,6 @@ contract RoomSystemTest is BaseTest {
   }
 
   function testCreateRoom() public {
-    setUp();
-
     vm.startPrank(alice);
     bytes32 playerId = world.ratroom__spawn("alice");
     vm.stopPrank();
@@ -48,8 +46,6 @@ contract RoomSystemTest is BaseTest {
   }
 
   function testLongRoomPrompt() public {
-    setUp();
-
     vm.startPrank(alice);
     bytes32 playerId = world.ratroom__spawn("alice");
     vm.stopPrank();
@@ -70,8 +66,6 @@ contract RoomSystemTest is BaseTest {
   }
 
   function testRevertBlanceTooLow() public {
-    setUp();
-
     vm.startPrank(alice);
     bytes32 playerId = world.ratroom__spawn("alice");
     vm.stopPrank();
@@ -84,8 +78,6 @@ contract RoomSystemTest is BaseTest {
   }
 
   function testCloseRoom() public {
-    setUp();
-
     vm.startPrank(alice);
     bytes32 playerId = world.ratroom__spawn("alice");
     vm.stopPrank();
@@ -119,8 +111,6 @@ contract RoomSystemTest is BaseTest {
   }
 
   function testCloseRoomRevertNotOwner() public {
-    setUp();
-
     vm.startPrank(alice);
     bytes32 aliceId = world.ratroom__spawn("alice");
     vm.stopPrank();


### PR DESCRIPTION
forge already invokes setUp before each test case, calling it a second time isn't needed and can cause problems

https://book.getfoundry.sh/forge/writing-tests