### PR TITLE
fix: prevent liquidation of null rat

### DIFF
--- a/packages/contracts/src/systems/RatSystem.sol
+++ b/packages/contracts/src/systems/RatSystem.sol
@@ -35,6 +35,8 @@ contract RatSystem is System {
     bytes32 playerId = LibUtils.addressToEntityKey(_msgSender());
     bytes32 ratId = OwnedRat.get(playerId);
 
+    require(ratId != bytes32(0), "no rat");
+
     // Check that the rat is alive
     require(!Dead.get(ratId), "rat is dead");
 

--- a/packages/contracts/test/systems/RatSystem.t.sol
+++ b/packages/contracts/test/systems/RatSystem.t.sol
@@ -83,6 +83,45 @@ contract RatSystemTest is BaseTest {
     vm.stopPrank();
   }
 
+  function testRevertLiquidateNoRat() public {
+    vm.startPrank(alice);
+    world.ratroom__spawn("alice");
+
+    world.ratroom__createRat("roger");
+
+    world.ratroom__liquidateRat();
+
+    vm.expectRevert("no rat");
+    world.ratroom__liquidateRat();
+
+    vm.stopPrank();
+  }
+
+  function testRevertLiquidateDeadRat() public {
+    setUp();
+
+    vm.startPrank(alice);
+    world.ratroom__spawn("alice");
+
+    bytes32 ratId = world.ratroom__createRat("roger");
+    vm.stopPrank();
+
+    prankAdmin();
+    Dead.set(ratId, true);
+    vm.stopPrank();
+
+    vm.startPrank(alice);
+    // Dead rat cannot be liquidated
+    vm.expectRevert("rat is dead");
+    world.ratroom__liquidateRat();
+
+    // But a new rat can be created
+    bytes32 newRatId = world.ratroom__createRat("roger");
+    vm.stopPrank();
+
+    assertNotEq(ratId, newRatId);
+  }
+
   function testDropItem() public {
     setUp();
 


### PR DESCRIPTION
2nd call of `liquidateRat` would detect `bytes32(0)` `ratId` as the owned rat and liquidate it
I added a check to match `dropItem`