### PR TITLE
fix: constrain room id in createRoom

### DIFF
--- a/packages/contracts/src/systems/RoomSystem.sol
+++ b/packages/contracts/src/systems/RoomSystem.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.24;
 import { console } from "forge-std/console.sol";
 import { System } from "@latticexyz/world/src/System.sol";
-import { GameConfig, Balance, Level, RoomCreationCost, LevelList, Owner } from "../codegen/index.sol";
+import { GameConfig, EntityType, Balance, Level, RoomCreationCost, LevelList, Owner } from "../codegen/index.sol";
 import { LibRoom, LibUtils } from "../libraries/Libraries.sol";
 import { MAX_ROOM_PROMPT_LENGTH } from "../constants.sol";
 import { ENTITY_TYPE } from "../codegen/common.sol";
@@ -31,6 +31,9 @@ contract RoomSystem is System {
     string memory _roomName,
     string memory _roomPrompt
   ) public onlyAdmin returns (bytes32 newRoomId) {
+    // Room id can be 0 (which generates a new id) or an unused entity id
+    require(_roomId == bytes32(0) || EntityType.get(_roomId) == ENTITY_TYPE.NONE, "room id already in use");
+
     // TODO: What level is room created on?
     // Currently hardcoded to level 0
     bytes32 levelId = LevelList.get()[0];

--- a/packages/contracts/test/systems/RoomSystem.t.sol
+++ b/packages/contracts/test/systems/RoomSystem.t.sol
@@ -77,6 +77,18 @@ contract RoomSystemTest is BaseTest {
     vm.stopPrank();
   }
 
+  function testRevertIdAlreadyInUse() public {
+    vm.startPrank(alice);
+    bytes32 playerId = world.ratroom__spawn("alice");
+    vm.stopPrank();
+
+    prankAdmin();
+    world.ratroom__createRoom(playerId, bytes32(hex"123456"), "Test room", "A test room");
+    vm.expectRevert("room id already in use");
+    world.ratroom__createRoom(playerId, bytes32(hex"123456"), "Test room", "A test room");
+    vm.stopPrank();
+  }
+
   function testCloseRoom() public {
     vm.startPrank(alice);
     bytes32 playerId = world.ratroom__spawn("alice");


### PR DESCRIPTION
createRoom is admin-locked, but it's still useful to check for weird externally-provided ids to avoid hard-to-detect bugs. I didn't actually check how exactly the id is generated by the server - hopefully there are no intentional id overwrites