### PR TITLE
account kit fix

### DIFF
--- a/packages/client/src/app.d.ts
+++ b/packages/client/src/app.d.ts
@@ -23,4 +23,4 @@ declare module '@latticexyz/account-kit/bundle' {
 	}): void;
 }
 
-export {};
+export { };

--- a/packages/client/src/lib/components/Main/RatContainer/DeployRat/DeployRat.svelte
+++ b/packages/client/src/lib/components/Main/RatContainer/DeployRat/DeployRat.svelte
@@ -11,7 +11,6 @@
 	import BigButton from '$lib/components/Main/Shared/Buttons/BigButton.svelte';
 
 	let busy = $state(false);
-	let done = $state(false);
 
 	const name: string = generateRatName();
 
@@ -29,8 +28,8 @@
 			await waitForCompletion(createRatAction);
 		} catch (e) {
 			console.error(e);
+			busy = false;
 		} finally {
-			done = true;
 			sendDeployRatMessage($walletNetwork);
 		}
 	}

--- a/packages/client/src/lib/components/Main/RoomContainer/CreateRoom/CreateRoom.svelte
+++ b/packages/client/src/lib/components/Main/RoomContainer/CreateRoom/CreateRoom.svelte
@@ -42,17 +42,22 @@
 		busy = true;
 		const newPrompt = roomDescription;
 
-		const approveAction = approve(
-			$gameConfig.externalAddressesConfig.gamePoolAddress,
-			roomCreationCost
-		);
-		await waitForCompletion(approveAction);
+		try {
+			const approveAction = approve(
+				$gameConfig.externalAddressesConfig.gamePoolAddress,
+				roomCreationCost
+			);
+			await waitForCompletion(approveAction);
+		} catch (e) {
+			console.error(e);
+			busy = false;
+			return;
+		}
 
 		const result = await createRoom(page.data.environment, $walletNetwork, newPrompt, levelId);
 		busy = false;
 
 		if (result.roomId) {
-			busy = false;
 			// console.log(result)
 			// Go to the preview
 			goto(`/${result.roomId}`);

--- a/packages/client/src/lib/components/Spawn/Spawn.svelte
+++ b/packages/client/src/lib/components/Spawn/Spawn.svelte
@@ -69,7 +69,7 @@
 		// Main user address => accountKitStoreState.userAddress
 		console.log('accountKitConnectReturn.userAddress', accountKitConnectReturn.userAddress);
 
-		const isSpawned = initWalletNetwork(wallet, accountKitConnectReturn.userAddress as Hex);
+		const isSpawned = initWalletNetwork(wallet, accountKitConnectReturn.userAddress as Hex, WALLET_TYPE.ACCOUNTKIT);
 
 		if (isSpawned) {
 			// Connected and spawned - go to next step
@@ -82,7 +82,7 @@
 
 	async function connectBurner() {
 		const wallet = setupBurnerWalletNetwork($publicNetwork);
-		const isSpawned = initWalletNetwork(wallet, wallet.walletClient?.account.address);
+		const isSpawned = initWalletNetwork(wallet, wallet.walletClient?.account.address, WALLET_TYPE.BURNER);
 
 		// Check if player is already spawned
 		if (isSpawned) {
@@ -113,7 +113,7 @@
 				// Main user address => accountKitStoreState.userAddress
 				console.log('accountKitStoreState.userAddress', accountKitStoreState.userAddress);
 
-				const isSpawned = initWalletNetwork(wallet, accountKitStoreState.userAddress);
+				const isSpawned = initWalletNetwork(wallet, accountKitStoreState.userAddress, walletType);
 
 				if (isSpawned) {
 					// Connected and spawned - go to next step

--- a/packages/client/src/lib/initWalletNetwork.ts
+++ b/packages/client/src/lib/initWalletNetwork.ts
@@ -1,13 +1,15 @@
 import type { SetupWalletNetworkResult } from "$lib/mud/setupWalletNetwork";
 import type { Hex } from "viem";
-import { ENTITY_TYPE } from "contracts/enums"; 
+import { ENTITY_TYPE } from "contracts/enums";
 import { get } from "svelte/store"
-import { walletNetwork } from "$lib/modules/network";
+import { walletNetwork, walletType } from "$lib/modules/network";
 import { player, playerAddress } from "$lib/modules/state/base/stores";
 import { initActionSequencer } from "$lib/modules/action/actionSequencer";
 import { initErc20Listener } from "$lib/modules/state/base/erc20Listener";
+import { WALLET_TYPE } from "./mud/enums";
 
-export function initWalletNetwork(wallet: SetupWalletNetworkResult, address: Hex) {
+export function initWalletNetwork(wallet: SetupWalletNetworkResult, address: Hex, type: WALLET_TYPE) {
+    walletType.set(type);
     walletNetwork.set(wallet);
     playerAddress.set(address);
     initActionSequencer();

--- a/packages/client/src/lib/modules/account-kit/types.ts
+++ b/packages/client/src/lib/modules/account-kit/types.ts
@@ -1,4 +1,4 @@
-import type { AppAccountClient } from "@latticexyz/account-kit/src/common";
+import type { AppAccountClient } from "@latticexyz/account-kit/bundle";
 
 export type AccountKitConnectReturn = {
     appAccountClient: AppAccountClient

--- a/packages/client/src/lib/modules/action/actionSequencer/utils.ts
+++ b/packages/client/src/lib/modules/action/actionSequencer/utils.ts
@@ -65,7 +65,9 @@ export const waitForCompletion = (
   loadingFunction?: (index: number) => void
 ): Promise<Action> => {
   return new Promise((resolve, reject) => {
-    const maxRetries = 150
+    // Much longer timeout if the action must be signed via the user's wallet,
+    // which has its own UI and can take arbitrarily long
+    const maxRetries = action.useUserAccount ? 15000 : 150
     let attempts = 0
     let index = 0
 

--- a/packages/client/src/lib/modules/action/index.ts
+++ b/packages/client/src/lib/modules/action/index.ts
@@ -1,3 +1,6 @@
+import { WALLET_TYPE } from "$lib/mud/enums"
+import { get } from "svelte/store"
+import { walletType } from "../network"
 import { addToSequencer } from "./actionSequencer"
 
 const NAMESPACE = "ratroom__"
@@ -9,7 +12,7 @@ export enum WorldFunctions {
   DropItem = NAMESPACE + "dropItem",
   CloseRoom = NAMESPACE + "closeRoom",
   Approve = "ERC20-approve",
-  GiveCallerTokens =  NAMESPACE + "giveCallerTokens"
+  GiveCallerTokens = NAMESPACE + "giveCallerTokens"
 }
 
 // --- API --------------------------------------------------------------
@@ -36,7 +39,8 @@ export function closeRoom(roomId: string) {
 
 export function approve(address: string, value: bigint) {
   const scaledValue = value * 10n ** 18n
-  return addToSequencer(WorldFunctions.Approve, [address, scaledValue])
+  const useUserAccount = get(walletType) === WALLET_TYPE.ACCOUNTKIT
+  return addToSequencer(WorldFunctions.Approve, [address, scaledValue], useUserAccount)
 }
 
 export function giveCallerTokens() {

--- a/packages/client/src/lib/modules/network/index.ts
+++ b/packages/client/src/lib/modules/network/index.ts
@@ -1,6 +1,7 @@
 import { writable } from "svelte/store";
 import { SetupPublicNetworkResult } from "$lib/mud/setupPublicNetwork";
 import { SetupWalletNetworkResult } from "$lib/mud/setupWalletNetwork";
+import { WALLET_TYPE } from "$lib/mud/enums";
 
 // ----------------------------------------------------------------------------
 
@@ -13,3 +14,4 @@ export const walletNetwork = writable({} as SetupWalletNetworkResult);
 export const blockNumber = writable(BigInt(0));
 export const ready = writable(false);
 export const loadingMessage = writable("Loading");
+export const walletType = writable(WALLET_TYPE.BURNER as WALLET_TYPE);


### PR DESCRIPTION
the new `useUserAccount` Action option essentially delegates the UI to the wallet provider, changing the wallet client and drastically increasing action timeout (since users could spend some time inspecting approval, maybe forget about it and come back later)

I also allowed rat/room creation to unset `busy` on error, since errors are expected because users can intentionally/accidentally reject approval