### PR TITLE
feat: track pool allowance, attempt unlimited approval at spawn

### DIFF
--- a/packages/client/src/lib/components/Main/RatContainer/DeployRat/DeployRat.svelte
+++ b/packages/client/src/lib/components/Main/RatContainer/DeployRat/DeployRat.svelte
@@ -2,10 +2,9 @@
   import { createRat, approve } from "$lib/modules/action"
   import { waitForCompletion } from "$lib/modules/action/actionSequencer/utils"
   import { playSound } from "$lib/modules/sound"
-  import { gameConfig, playerERC20Balance } from "$lib/modules/state/base/stores"
+  import { gameConfig, playerERC20Allowance, playerERC20Balance } from "$lib/modules/state/base/stores"
   import { generateRatName } from "./index"
   import { sendDeployRatMessage } from "$lib/modules/off-chain-sync"
-  import { walletNetwork } from "$lib/modules/network"
 
   import VideoLoader from "$lib/components/Main/Shared/Loaders/VideoLoader.svelte"
   import BigButton from "$lib/components/Main/Shared/Buttons/BigButton.svelte"
@@ -19,11 +18,13 @@
     playSound("tcm", "blink")
     busy = true
     try {
-      const approveAction = approve(
-        $gameConfig.externalAddressesConfig.gamePoolAddress,
-        $gameConfig.gameConfig.ratCreationCost
-      )
-      await waitForCompletion(approveAction)
+      if ($playerERC20Allowance < $gameConfig.gameConfig.ratCreationCost) {
+        const approveAction = approve(
+          $gameConfig.externalAddressesConfig.gamePoolAddress,
+          $gameConfig.gameConfig.ratCreationCost
+        )
+        await waitForCompletion(approveAction)
+      }
       const createRatAction = createRat(name)
       await waitForCompletion(createRatAction)
     } catch (e) {

--- a/packages/client/src/lib/components/Main/RoomContainer/CreateRoom/CreateRoom.svelte
+++ b/packages/client/src/lib/components/Main/RoomContainer/CreateRoom/CreateRoom.svelte
@@ -5,7 +5,8 @@
     rat,
     gameConfig,
     levels,
-    playerERC20Balance
+    playerERC20Balance,
+    playerERC20Allowance
   } from "$lib/modules/state/base/stores"
   import { waitForCompletion } from "$lib/modules/action/actionSequencer/utils"
   import { createRoom } from "./index"
@@ -40,11 +41,13 @@
     const newPrompt = roomDescription
 
     try {
-      const approveAction = approve(
-        $gameConfig.externalAddressesConfig.gamePoolAddress,
-        roomCreationCost
-      )
-      await waitForCompletion(approveAction)
+      if ($playerERC20Allowance < $gameConfig.gameConfig.ratCreationCost) {
+        const approveAction = approve(
+          $gameConfig.externalAddressesConfig.gamePoolAddress,
+          roomCreationCost
+        )
+        await waitForCompletion(approveAction)
+      }
     } catch (e) {
       console.error(e)
       busy = false

--- a/packages/client/src/lib/components/Spawn/Spawn.svelte
+++ b/packages/client/src/lib/components/Spawn/Spawn.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Hex } from "viem"
+  import { maxUint256, type Hex } from "viem"
   import type { SetupWalletNetworkResult } from "$lib/mud/setupWalletNetwork"
 
   import { WALLET_TYPE } from "$lib/mud/enums"
@@ -10,7 +10,8 @@
   import { store as accountKitStore } from "@latticexyz/account-kit/bundle"
 
   import { onMount } from "svelte"
-  import { spawn } from "$lib/modules/action"
+  import { gameConfig, playerERC20Allowance } from "$lib/modules/state/base/stores"
+  import { approveMax, spawn } from "$lib/modules/action"
   import { waitForCompletion } from "$lib/modules/action/actionSequencer/utils"
   import { playSound } from "$lib/modules/sound"
   import { publicNetwork } from "$lib/modules/network"
@@ -74,6 +75,15 @@
       accountKitConnectReturn.userAddress as Hex,
       WALLET_TYPE.ACCOUNTKIT
     )
+
+    if ($playerERC20Allowance < 100) {
+      try {
+        const approveAction = approveMax($gameConfig.externalAddressesConfig.gamePoolAddress)
+        await waitForCompletion(approveAction)
+      } catch (e) {
+        console.error(e)
+      }
+    }
 
     if (isSpawned) {
       // Connected and spawned - go to next step

--- a/packages/client/src/lib/modules/action/index.ts
+++ b/packages/client/src/lib/modules/action/index.ts
@@ -1,3 +1,4 @@
+import { maxUint256 } from "viem"
 import { WALLET_TYPE } from "$lib/mud/enums"
 import { get } from "svelte/store"
 import { walletType } from "../network"
@@ -41,6 +42,11 @@ export function approve(address: string, value: bigint) {
   const scaledValue = value * 10n ** 18n
   const useUserAccount = get(walletType) === WALLET_TYPE.ACCOUNTKIT
   return addToSequencer(WorldFunctions.Approve, [address, scaledValue], useUserAccount)
+}
+
+export function approveMax(address: string) {
+  const useUserAccount = get(walletType) === WALLET_TYPE.ACCOUNTKIT
+  return addToSequencer(WorldFunctions.Approve, [address, maxUint256], useUserAccount)
 }
 
 export function giveCallerTokens() {

--- a/packages/client/src/lib/modules/state/base/erc20Listener.ts
+++ b/packages/client/src/lib/modules/state/base/erc20Listener.ts
@@ -1,52 +1,77 @@
 import { derived } from "svelte/store"
 import { erc20Abi, Hex, parseAbiItem } from "viem"
 import { publicNetwork } from "$lib/modules/network"
-import { gameConfig, playerAddress, playerERC20Balance } from "$lib/modules/state/base/stores"
+import { gameConfig, playerAddress, playerERC20Allowance, playerERC20Balance } from "$lib/modules/state/base/stores"
 import { SetupPublicNetworkResult } from "$lib/mud/setupPublicNetwork"
 
 export function initErc20Listener() {
   let unwatchFrom: (() => void) | undefined
   let unwatchTo: (() => void) | undefined
+  let unwatchOwner: (() => void) | undefined
 
   derived([publicNetwork, playerAddress, gameConfig], stores => stores).subscribe(
     ([publicNetwork, playerAddress, gameConfig]) => {
       if (!publicNetwork || !playerAddress || !gameConfig?.externalAddressesConfig) return
 
       const address = gameConfig.externalAddressesConfig.erc20Address
-      const event = parseAbiItem(
+      const transferEvent = parseAbiItem(
         "event Transfer(address indexed from, address indexed to, uint256 value)"
       )
-      const onLogs = () =>
+      const approvalEvent = parseAbiItem(
+        "event Approval(address indexed owner, address indexed spender, uint256 value)"
+      )
+      const onTransferLogs = () =>
         updatePlayerERC20Balance(
           publicNetwork,
           playerAddress as Hex,
           gameConfig.externalAddressesConfig.erc20Address
         )
 
-      // Set initial balance
-      onLogs()
+      const onApprovalLogs = () => {
+        const spenderAddress = gameConfig.externalAddressesConfig.gamePoolAddress
+        updatePlayerERC20Allowance(
+          publicNetwork,
+          playerAddress as Hex,
+          spenderAddress,
+          gameConfig.externalAddressesConfig.erc20Address
+        )
+      }
+
+      // Set initial balance and allowance
+      onTransferLogs()
+      onApprovalLogs()
 
       unwatchFrom = publicNetwork.publicClient.watchEvent({
         address,
-        event,
+        event: transferEvent,
         args: {
           from: playerAddress as Hex
         },
-        onLogs
+        onLogs: onTransferLogs
       })
 
       unwatchTo = publicNetwork.publicClient.watchEvent({
         address,
-        event,
+        event: transferEvent,
         args: {
           to: playerAddress as Hex
         },
-        onLogs
+        onLogs: onTransferLogs
+      })
+
+      unwatchOwner = publicNetwork.publicClient.watchEvent({
+        address,
+        event: approvalEvent,
+        args: {
+          owner: playerAddress as Hex
+        },
+        onLogs: onApprovalLogs
       })
     },
     () => {
       unwatchFrom?.()
       unwatchTo?.()
+      unwatchOwner?.()
     }
   )
 }
@@ -64,4 +89,20 @@ async function updatePlayerERC20Balance(
   })
 
   playerERC20Balance.set(Number(balance / 10n ** 18n))
+}
+
+async function updatePlayerERC20Allowance(
+  publicNetwork: SetupPublicNetworkResult,
+  playerAddress: Hex,
+  spenderAddress: Hex,
+  erc20Address: Hex
+) {
+  const allowance = await publicNetwork.publicClient.readContract({
+    address: erc20Address,
+    abi: erc20Abi,
+    functionName: "allowance",
+    args: [playerAddress, spenderAddress]
+  })
+
+  playerERC20Allowance.set(Number(allowance / 10n ** 18n))
 }

--- a/packages/client/src/lib/modules/state/base/stores.ts
+++ b/packages/client/src/lib/modules/state/base/stores.ts
@@ -86,6 +86,7 @@ export const playerRooms = derived(
 )
 
 export const playerERC20Balance = writable(0 as number)
+export const playerERC20Allowance = writable(0 as number)
 
 // * * * * * * * * * * * * * * * * *
 // PLAYER RAT STORES


### PR DESCRIPTION
If unlimited approval is rejected, it will be attempted at another wallet connection (you could add some ui to let users explicitly permanently reject unlimited approval popup so it doesn't keep bothering them)

Each rat/room creation checks allowances and requests individual approval if necessary