### PR TITLE
refactor: use a file for message store

### DIFF
--- a/packages/server/src/modules/message-store/index.ts
+++ b/packages/server/src/modules/message-store/index.ts
@@ -1,8 +1,12 @@
-import { Low, Memory } from "lowdb"
+import { mkdirSync } from "fs"
+import { Low } from "lowdb"
+import { JSONFile } from "lowdb/node"
 import { OffChainMessage, MessageDatabaseSchema } from "@modules/types"
 
-// Initialize the database with in-memory adapter
-const adapter = new Memory<MessageDatabaseSchema>()
+// Initialize the database with file adapter
+// (the file can be periodically pruned/deleted, only the last few messages are needed)
+mkdirSync("db-files", { recursive: true })
+const adapter = new JSONFile<MessageDatabaseSchema>("db-files/messages.json")
 const db = new Low<MessageDatabaseSchema>(adapter, { messages: [] })
 
 // Initialize the database


### PR DESCRIPTION
- a file is easy to manually prune without restarting the server
- it persists between restarts if you don't actually mean to prune it
- you likely have far more disk storage than ram



(I'm using the same `db-files` structure as with nonces)