### PR TITLE
feat: improve react sync, react to svelte portal, chain switching

### DIFF
--- a/packages/client/src/lib/components/Loading/Loading.svelte
+++ b/packages/client/src/lib/components/Loading/Loading.svelte
@@ -46,8 +46,6 @@
   })
 </script>
 
-<EntryKit hidden />
-
 <div class="loading">
   <div class="inner" bind:this={innerElement}>
     <img src="/images/logo.png" alt="logo" />

--- a/packages/client/src/lib/components/Spawn/ConnectWalletForm/ConnectWalletForm.svelte
+++ b/packages/client/src/lib/components/Spawn/ConnectWalletForm/ConnectWalletForm.svelte
@@ -3,8 +3,8 @@
   import { onMount } from "svelte"
   import gsap from "gsap"
 
-  import EntryKit from "$lib/components/Spawn/EntryKit/EntryKit.svelte"
   import BigButton from "$lib/components/Shared/Buttons/BigButton.svelte"
+  import { entryKitButton } from "$lib/modules/entry-kit/stores"
 
   const { walletType, onComplete = () => {} } = $props<{
     walletType: WALLET_TYPE
@@ -53,7 +53,8 @@
     <img src="/images/bouncer2.png" alt="BASE(TM) ID" bind:this={imageElement} />
     <p bind:this={messageElement}>{message}</p>
     {#if walletType === WALLET_TYPE.ENTRYKIT}
-      <EntryKit />
+      <div bind:this={$entryKitButton}>
+      </div>
     {:else}
       <div bind:this={buttonElement}>
         <BigButton text="Connect Burner" onclick={onComplete} />

--- a/packages/client/src/lib/modules/entry-kit/SessionBridge.ts
+++ b/packages/client/src/lib/modules/entry-kit/SessionBridge.ts
@@ -1,13 +1,12 @@
 import { useEffect } from "react"
-import { useEntryKitConfig, useSessionClient } from "@latticexyz/entrykit/internal"
-import { entryKitConnector, entryKitSession } from "$lib/modules/entry-kit/stores"
-import { useWalletClient } from "wagmi"
+import { useSessionClient } from "@latticexyz/entrykit/internal"
+import { wagmiConfigStateful, entryKitSession } from "$lib/modules/entry-kit/stores"
+import { useConfig } from "wagmi"
 
 export default function SessionBridge() {
-  const { chainId } = useEntryKitConfig()
   const sessionClient = useSessionClient()
 
-  const connectorClient = useWalletClient({ chainId })
+  const wagmiConfig = useConfig()
 
   // Transfer session updates to svelte store
   useEffect(() => {
@@ -15,11 +14,11 @@ export default function SessionBridge() {
     console.log("We have established the bridge between entrykit and the app", sessionClient.data)
   }, [sessionClient.data])
 
-  // Transfer connector updates to svelte store
+  // Transfer wagmi config state updates to svelte store
   useEffect(() => {
-    entryKitConnector.set(connectorClient.data)
-    console.log("We have set up the connector for entrykit and the app", connectorClient.data)
-  }, [connectorClient.data])
+    wagmiConfigStateful.set(wagmiConfig)
+    console.log("We have synced entrykit's wagmi config state for use by the app", wagmiConfig)
+  }, [wagmiConfig, wagmiConfig.state])
 
   return null
 }

--- a/packages/client/src/lib/modules/entry-kit/stores.ts
+++ b/packages/client/src/lib/modules/entry-kit/stores.ts
@@ -1,9 +1,10 @@
-import type { Account, Chain, Transport, WalletClient } from "viem"
+import type { Chain } from "viem"
+import { Config } from "wagmi"
 import type { SessionClient } from "@latticexyz/entrykit/internal"
 import { writable } from "svelte/store"
 
 export const entryKitSession = writable<SessionClient<Chain> | undefined | null>(null)
 
-export const entryKitConnector = writable<
-  WalletClient<Transport, Chain, Account> | undefined | null
->(null)
+export const wagmiConfigStateful = writable<Config | null>(null)
+
+export const entryKitButton = writable<HTMLElement | null>(null)

--- a/packages/client/src/lib/modules/error-handling/errors.ts
+++ b/packages/client/src/lib/modules/error-handling/errors.ts
@@ -104,9 +104,9 @@ export class WorldAddressNotFoundError extends BlockchainError {
   }
 }
 
-export class ConnectorClientUnavailableError extends BlockchainError {
-  constructor(message: string = "Connector client is not available") {
-    super("CONNECTOR_CLIENT_UNAVAILABLE", "Wallet connection error", message)
+export class WagmiConfigUnavailableError extends BlockchainError {
+  constructor(message: string = "Wagmi config is not available") {
+    super("WAGMI_CONFIG_UNAVAILABLE", "Wallet connection error", message)
   }
 }
 
@@ -369,7 +369,7 @@ export type ExpectedError =
   | ContractCallError
   | ChainConfigError
   | WorldAddressNotFoundError
-  | ConnectorClientUnavailableError
+  | WagmiConfigUnavailableError
   | BlockTimeoutError
   | GraphicsError
   | WebGLError

--- a/packages/client/src/routes/+layout.svelte
+++ b/packages/client/src/routes/+layout.svelte
@@ -35,6 +35,7 @@
     WorldEventPopup
   } from "$lib/components/Shared"
   import { Outcome } from "$lib/components/Room"
+  import EntryKit from "$lib/components/Spawn/EntryKit/EntryKit.svelte"
 
   let { children, data }: LayoutProps = $props()
 
@@ -134,6 +135,8 @@
     content={worldEventContent}
   ></ModalTarget>
 {/if}
+
+<EntryKit />
 
 <Modal />
 


### PR DESCRIPTION
I think I figured out a nicer way to do react-svelte interop:
`EntryKit` is always rendered in loadout, not displayed, and actual components (just AccountButton here) are rendered to svelte's bound dom elements (via binding to a subscribable store)

Also improved related wagmi sync and chain switch

From the user's perspective this should fix issues with automatic chain switches, especially for unexpected chains