### PR TITLE
feat: use base api for bundler, paymaster, rpc

### DIFF
--- a/packages/client/src/lib/modules/entry-kit/paymasters.ts
+++ b/packages/client/src/lib/modules/entry-kit/paymasters.ts
@@ -5,13 +5,13 @@ export const paymasters: Record<number, PaymasterClient | undefined> = {
   // Base Mainnet
   8453: createPaymasterClient({
     transport: http(
-      "https://api.developer.coinbase.com/rpc/v1/base/W8ndwUET2baGUDK2aHIEPg7s7iP0xOzU"
+      "https://api.developer.coinbase.com/rpc/v1/base/3ewNiMtI6Vj7q6XobGjyWILDJNKFHkh1"
     )
   }),
   // Base Sepolia
   84532: createPaymasterClient({
     transport: http(
-      "https://api.developer.coinbase.com/rpc/v1/base-sepolia/W8ndwUET2baGUDK2aHIEPg7s7iP0xOzU"
+      "https://api.developer.coinbase.com/rpc/v1/base-sepolia/3ewNiMtI6Vj7q6XobGjyWILDJNKFHkh1"
     )
   })
 }

--- a/packages/client/src/lib/mud/extendedChainConfigs/extendedBase.ts
+++ b/packages/client/src/lib/mud/extendedChainConfigs/extendedBase.ts
@@ -3,5 +3,13 @@ import { type MUDChain } from "@latticexyz/common/chains"
 
 export const extendedBase = {
   ...baseConfig,
+  rpcUrls: {
+    default: {
+      http: ["https://api.developer.coinbase.com/rpc/v1/base/3ewNiMtI6Vj7q6XobGjyWILDJNKFHkh1"]
+    },
+    bundler: {
+      http: ["https://api.developer.coinbase.com/rpc/v1/base/3ewNiMtI6Vj7q6XobGjyWILDJNKFHkh1"]
+    }
+  },
   indexerUrl: "https://base.rat-fun-indexer.com"
 } as const satisfies MUDChain

--- a/packages/client/src/lib/mud/extendedChainConfigs/extendedBaseSepolia.ts
+++ b/packages/client/src/lib/mud/extendedChainConfigs/extendedBaseSepolia.ts
@@ -4,9 +4,11 @@ import { type MUDChain } from "@latticexyz/common/chains"
 export const extendedBaseSepolia = {
   ...baseSepoliaConfig,
   rpcUrls: {
-    ...baseSepoliaConfig.rpcUrls,
+    default: {
+      http: ["https://api.developer.coinbase.com/rpc/v1/base-sepolia/3ewNiMtI6Vj7q6XobGjyWILDJNKFHkh1x"]
+    },
     bundler: {
-      http: ["https://api.pimlico.io/v2/84532/rpc?apikey=pim_8gQqpbnmKF1njADAZmuHy5"]
+      http: ["https://api.developer.coinbase.com/rpc/v1/base-sepolia/3ewNiMtI6Vj7q6XobGjyWILDJNKFHkh1"]
     }
   },
   indexerUrl: "https://base-sepolia.rat-fun-indexer.com",


### PR DESCRIPTION
Base conveniently has the same url for all the apis, and given that you will have free credits there I assume there's no reason to stick to pimlico for bundler
I also changed paymaster from mine to the one arb created

You should configure paymaster limits for testnet before a playtest, they're very low atm
https://portal.cdp.coinbase.com/products/paymaster/configuration?projectId=e97584c7-e4d6-4de7-a0e7-3a6d479cc356

And configure the domain allowlist, it'll break everything otherwise 
https://portal.cdp.coinbase.com/projects/api-keys/client-key?projectId=e97584c7-e4d6-4de7-a0e7-3a6d479cc356